### PR TITLE
Add function to get current `DateTimeComponent` in decimal

### DIFF
--- a/src/RV3028C7.cpp
+++ b/src/RV3028C7.cpp
@@ -85,6 +85,25 @@ char *RV3028C7::getCurrentDateTime()
   return iso8601;
 }
 
+uint8_t RV3028C7::getCurrentDateTimeComponent(DateTimeComponent_t component)
+{
+  // Updates RTC date time value to array
+  readBytesFromRegisters(REG_CLOCK_SECONDS, _dateTime, DATETIME_COMPONENTS);
+
+  /*
+  component:
+  DATETIME_SECOND
+  DATETIME_MINUTE
+  DATETIME_HOUR
+  DATETIME_DAY_OF_WEEK
+  DATETIME_DAY_OF_MONTH
+  DATETIME_MONTH
+  DATETIME_YEAR
+  */
+
+  return convertToDecimal(_dateTime[component]);
+}
+
 void RV3028C7::setDateTimeFromISO8601(String iso8601)
 {
   return setDateTimeFromISO8601(iso8601.c_str());

--- a/src/RV3028C7.cpp
+++ b/src/RV3028C7.cpp
@@ -12,33 +12,42 @@
 
 RV3028C7::RV3028C7() {}
 
-bool RV3028C7::begin(TwoWire &wirePort) {
+bool RV3028C7::begin(TwoWire &wirePort)
+{
   // Wire.begin() should be called in the application code in advance
   _i2cPort = &wirePort;
 
   // Reads RESET bit to pseudo-verify that the part is a RV-3028-C7
   uint8_t value = readByteFromRegister(REG_CONTROL_2);
-  if ((value & 0x01) == 0x00) {
+  if ((value & 0x01) == 0x00)
+  {
     return true;
-  } else {
+  }
+  else
+  {
     return false;
   }
 }
 
-uint32_t RV3028C7::getUnixTimestamp() {
+uint32_t RV3028C7::getUnixTimestamp()
+{
   uint8_t ts[4];
   readBytesFromRegisters(REG_UNIX_TIME_0, ts, 4);
   uint32_t result1 = (ts[3] << 24) | (ts[2] << 16) | (ts[1] << 8) | ts[0];
   readBytesFromRegisters(REG_UNIX_TIME_0, ts, 4);
   uint32_t result2 = (ts[3] << 24) | (ts[2] << 16) | (ts[1] << 8) | ts[0];
-  if (result1 == result2) {
+  if (result1 == result2)
+  {
     return result1;
-  } else {
+  }
+  else
+  {
     return getUnixTimestamp();
   }
 }
 
-bool RV3028C7::setUnixTimestamp(uint32_t secondsSinceEpoch, bool syncCalendar) {
+bool RV3028C7::setUnixTimestamp(uint32_t secondsSinceEpoch, bool syncCalendar)
+{
   bool success = false;
 
   uint8_t ts[4] = {
@@ -46,7 +55,8 @@ bool RV3028C7::setUnixTimestamp(uint32_t secondsSinceEpoch, bool syncCalendar) {
       (uint8_t)(secondsSinceEpoch >> 16), (uint8_t)(secondsSinceEpoch >> 24)};
   success = writeBytesToRegisters(REG_UNIX_TIME_0, ts, 4);
 
-  if (syncCalendar) {
+  if (syncCalendar)
+  {
     time_t t = secondsSinceEpoch;
     struct tm *dateTime = gmtime(&t);
     success = setDateTime(dateTime->tm_year + 1900, dateTime->tm_mon + 1,
@@ -58,7 +68,8 @@ bool RV3028C7::setUnixTimestamp(uint32_t secondsSinceEpoch, bool syncCalendar) {
   return success;
 }
 
-char *RV3028C7::getCurrentDateTime() {
+char *RV3028C7::getCurrentDateTime()
+{
   // Updates RTC date time value to array
   readBytesFromRegisters(REG_CLOCK_SECONDS, _dateTime, DATETIME_COMPONENTS);
 
@@ -74,17 +85,20 @@ char *RV3028C7::getCurrentDateTime() {
   return iso8601;
 }
 
-void RV3028C7::setDateTimeFromISO8601(String iso8601) {
+void RV3028C7::setDateTimeFromISO8601(String iso8601)
+{
   return setDateTimeFromISO8601(iso8601.c_str());
 }
 
-void RV3028C7::setDateTimeFromISO8601(const char *iso8601) {
+void RV3028C7::setDateTimeFromISO8601(const char *iso8601)
+{
   // Assumes the input is in the format of "2018-01-01T08:00:00" (hundredths and
   // time zone, if applicable, will be neglected)
   char components[3] = {'0', '0', '\0'};
   uint8_t buffer[6];
 
-  for (uint8_t i = 2, j = 0; i < 20; i += 3, j++) {
+  for (uint8_t i = 2, j = 0; i < 20; i += 3, j++)
+  {
     components[0] = iso8601[i];
     components[1] = iso8601[i + 1];
     buffer[j] = atoi(components);
@@ -97,43 +111,61 @@ void RV3028C7::setDateTimeFromISO8601(const char *iso8601) {
               /*hour=*/buffer[3], /*minute=*/buffer[4], /*second=*/buffer[5]);
 }
 
-void RV3028C7::setDateTimeFromHTTPHeader(String str) {
+void RV3028C7::setDateTimeFromHTTPHeader(String str)
+{
   return setDateTimeFromHTTPHeader(str.c_str());
 }
 
-void RV3028C7::setDateTimeFromHTTPHeader(const char *str) {
+void RV3028C7::setDateTimeFromHTTPHeader(const char *str)
+{
   char components[3] = {'0', '0', '\0'};
 
   // Checks whether the string begins with "Date: " prefix
   uint8_t counter = 0;
-  if (str[0] == 'D') {
+  if (str[0] == 'D')
+  {
     counter = 6;
   }
 
   // Day of week
   uint8_t dayOfWeek = 0;
-  if (str[counter] == 'T') {
+  if (str[counter] == 'T')
+  {
     // Tue or Thu
-    if (str[counter + 1] == 'u') {
+    if (str[counter + 1] == 'u')
+    {
       // Tue
       dayOfWeek = 2;
-    } else {
+    }
+    else
+    {
       dayOfWeek = 4;
     }
-  } else if (str[counter] == 'S') {
+  }
+  else if (str[counter] == 'S')
+  {
     // Sat or Sun
-    if (str[counter + 1] == 'a') {
+    if (str[counter + 1] == 'a')
+    {
       dayOfWeek = 6;
-    } else {
+    }
+    else
+    {
       dayOfWeek = 0;
     }
-  } else if (str[counter] == 'M') {
+  }
+  else if (str[counter] == 'M')
+  {
     // Mon
     dayOfWeek = 1;
-  } else if (str[counter] == 'W') {
+  }
+  else if (str[counter] == 'W')
+  {
     // Wed
     dayOfWeek = 3;
-  } else {
+  }
+  else
+  {
     // Fri
     dayOfWeek = 5;
   }
@@ -147,49 +179,75 @@ void RV3028C7::setDateTimeFromHTTPHeader(const char *str) {
   // Month
   counter += 3;
   uint8_t month = 0;
-  if (str[counter] == 'J') {
+  if (str[counter] == 'J')
+  {
     // Jan, Jun, or Jul
-    if (str[counter + 1] == 'a') {
+    if (str[counter + 1] == 'a')
+    {
       // Jan
       month = 1;
-    } else if (str[counter + 2] == 'n') {
+    }
+    else if (str[counter + 2] == 'n')
+    {
       // Jun
       month = 6;
-    } else {
+    }
+    else
+    {
       // Jul
       month = 7;
     }
-  } else if (str[counter] == 'F') {
+  }
+  else if (str[counter] == 'F')
+  {
     // Feb
     month = 2;
-  } else if (str[counter] == 'M') {
+  }
+  else if (str[counter] == 'M')
+  {
     // Mar or May
-    if (str[counter + 2] == 'r') {
+    if (str[counter + 2] == 'r')
+    {
       // Mar
       month = 3;
-    } else {
+    }
+    else
+    {
       // May
       month = 5;
     }
-  } else if (str[counter] == 'A') {
+  }
+  else if (str[counter] == 'A')
+  {
     // Apr or Aug
-    if (str[counter + 1] == 'p') {
+    if (str[counter + 1] == 'p')
+    {
       // Apr
       month = 4;
-    } else {
+    }
+    else
+    {
       // Aug
       month = 8;
     }
-  } else if (str[counter] == 'S') {
+  }
+  else if (str[counter] == 'S')
+  {
     // Sep
     month = 9;
-  } else if (str[counter] == 'O') {
+  }
+  else if (str[counter] == 'O')
+  {
     // Oct
     month = 10;
-  } else if (str[counter] == 'N') {
+  }
+  else if (str[counter] == 'N')
+  {
     // Nov
     month = 11;
-  } else {
+  }
+  else
+  {
     month = 12;
   }
 
@@ -202,7 +260,8 @@ void RV3028C7::setDateTimeFromHTTPHeader(const char *str) {
   // Time of day
   counter += 3;
   uint8_t buffer[3];
-  for (uint8_t i = counter, j = 0; j < 3; i += 3, j++) {
+  for (uint8_t i = counter, j = 0; j < 3; i += 3, j++)
+  {
     components[0] = str[i];
     components[1] = str[i + 1];
     buffer[j] = atoi(components);
@@ -214,47 +273,56 @@ void RV3028C7::setDateTimeFromHTTPHeader(const char *str) {
 
 bool RV3028C7::setDateTime(uint16_t year, uint8_t month, uint8_t dayOfMonth,
                            DayOfWeek_t dayOfWeek, uint8_t hour, uint8_t minute,
-                           uint8_t second, bool syncUnixTime) {
+                           uint8_t second, bool syncUnixTime)
+{
   // Year 2000 AD is the earliest allowed year in this implementation
-  if (year < 2000) {
+  if (year < 2000)
+  {
     return false;
   }
   // Century overflow is not considered yet (i.e., only supports year 2000 to
   // 2099)
   _dateTime[DATETIME_YEAR] = convertToBCD(year - 2000);
 
-  if (month < 1 || month > 12) {
+  if (month < 1 || month > 12)
+  {
     return false;
   }
   _dateTime[DATETIME_MONTH] = convertToBCD(month);
 
-  if (dayOfMonth < 1 || dayOfMonth > 31) {
+  if (dayOfMonth < 1 || dayOfMonth > 31)
+  {
     return false;
   }
   _dateTime[DATETIME_DAY_OF_MONTH] = convertToBCD(dayOfMonth);
 
-  if (dayOfWeek > 6) {
+  if (dayOfWeek > 6)
+  {
     return false;
   }
   _dateTime[DATETIME_DAY_OF_WEEK] = convertToBCD(dayOfWeek);
 
   // Uses 24-hour notation by default
-  if (hour > 23) {
+  if (hour > 23)
+  {
     return false;
   }
   _dateTime[DATETIME_HOUR] = convertToBCD(hour);
 
-  if (minute > 59) {
+  if (minute > 59)
+  {
     return false;
   }
   _dateTime[DATETIME_MINUTE] = convertToBCD(minute);
 
-  if (second > 59) {
+  if (second > 59)
+  {
     return false;
   }
   _dateTime[DATETIME_SECOND] = convertToBCD(second);
 
-  if (syncUnixTime) {
+  if (syncUnixTime)
+  {
     uint32_t unixTimestamp =
         convertToUnixTimestamp(year, month, dayOfMonth, hour, minute, second);
     setUnixTimestamp(unixTimestamp, false);
@@ -264,22 +332,26 @@ bool RV3028C7::setDateTime(uint16_t year, uint8_t month, uint8_t dayOfMonth,
 }
 
 void RV3028C7::setDateTimeComponent(DateTimeComponent_t component,
-                                    uint8_t value) {
+                                    uint8_t value)
+{
   // Updates RTC date time value to array
   readBytesFromRegisters(REG_CLOCK_SECONDS, _dateTime, DATETIME_COMPONENTS);
 
   _dateTime[component] = convertToBCD(value);
 }
 
-bool RV3028C7::synchronize() {
+bool RV3028C7::synchronize()
+{
   return writeBytesToRegisters(REG_CLOCK_SECONDS, _dateTime,
                                DATETIME_COMPONENTS);
 }
 
-bool RV3028C7::enableClockOutput(ClockOutputFrequency_t frequency) {
+bool RV3028C7::enableClockOutput(ClockOutputFrequency_t frequency)
+{
   uint8_t clkout = readByteFromEEPROM(REG_EEPROM_CLKOUT);
   if ((clkout & (1 << BP_REG_EEPROM_CLKOUT_CLKOE)) > 0 &&
-      (clkout & BM_REG_EEPROM_CLKOUT_FD) == frequency) {
+      (clkout & BM_REG_EEPROM_CLKOUT_FD) == frequency)
+  {
     // Already enabled at desired frequency
     return true;
   }
@@ -295,9 +367,11 @@ bool RV3028C7::enableClockOutput(ClockOutputFrequency_t frequency) {
          writeByteToEEPROM(REG_EEPROM_CLKOUT, clkout);
 }
 
-bool RV3028C7::disableClockOutput() {
+bool RV3028C7::disableClockOutput()
+{
   uint8_t clkout = readByteFromEEPROM(REG_EEPROM_CLKOUT);
-  if ((clkout & (1 << BP_REG_EEPROM_CLKOUT_CLKOE)) == 0) {
+  if ((clkout & (1 << BP_REG_EEPROM_CLKOUT_CLKOE)) == 0)
+  {
     // Already disabled
     return true;
   }
@@ -310,22 +384,26 @@ bool RV3028C7::disableClockOutput() {
 }
 
 bool RV3028C7::setDateAlarm(AlarmMode_t mode, uint8_t dayOfMonth, uint8_t hour,
-                            uint8_t minute) {
+                            uint8_t minute)
+{
   // Clears AIE and AF bits to 0
   uint8_t status = readByteFromRegister(REG_STATUS);
-  if (!writeByteToRegister(REG_STATUS, (status & ~(1 << BP_REG_STATUS_AF)))) {
+  if (!writeByteToRegister(REG_STATUS, (status & ~(1 << BP_REG_STATUS_AF))))
+  {
     return false;
   }
   uint8_t control2 = readByteFromRegister(REG_CONTROL_2);
   if (!writeByteToRegister(REG_CONTROL_2,
-                           (control2 & ~(1 << BP_REG_CONTROL_2_AIE)))) {
+                           (control2 & ~(1 << BP_REG_CONTROL_2_AIE))))
+  {
     return false;
   }
 
   // Sets WADA bit to 1
   uint8_t control1 = readByteFromRegister(REG_CONTROL_1);
   if (!writeByteToRegister(REG_CONTROL_1,
-                           (control1 | (1 << BP_REG_CONTROL_1_WADA)))) {
+                           (control1 | (1 << BP_REG_CONTROL_1_WADA))))
+  {
     return false;
   }
 
@@ -335,23 +413,32 @@ bool RV3028C7::setDateAlarm(AlarmMode_t mode, uint8_t dayOfMonth, uint8_t hour,
   uint8_t dateAlarm = convertToBCD(dayOfMonth);
 
   // Sets AE_x bits according to alarm mode
-  if (mode == ALARM_ONCE_PER_DAY_OF_MONTH_OR_WEEK) {
+  if (mode == ALARM_ONCE_PER_DAY_OF_MONTH_OR_WEEK)
+  {
     dateAlarm &= ~(1 << BP_ALARM_AE);    // AE_WD = 0
     hoursAlarm &= ~(1 << BP_ALARM_AE);   // AE_H = 0
     minutesAlarm &= ~(1 << BP_ALARM_AE); // AE_M = 0
-  } else if (mode == ALARM_ONCE_PER_HOUR_PER_DAY_OF_MONTH_OR_WEEK) {
+  }
+  else if (mode == ALARM_ONCE_PER_HOUR_PER_DAY_OF_MONTH_OR_WEEK)
+  {
     dateAlarm &= ~(1 << BP_ALARM_AE);    // AE_WD = 0
     hoursAlarm |= (1 << BP_ALARM_AE);    // AE_H = 1
     minutesAlarm &= ~(1 << BP_ALARM_AE); // AE_M = 0
-  } else if (mode == ALARM_ONCE_PER_DAY) {
+  }
+  else if (mode == ALARM_ONCE_PER_DAY)
+  {
     dateAlarm |= (1 << BP_ALARM_AE);     // AE_WD = 1
     hoursAlarm &= ~(1 << BP_ALARM_AE);   // AE_H = 0
     minutesAlarm &= ~(1 << BP_ALARM_AE); // AE_M = 0
-  } else if (mode == ALARM_ONCE_PER_HOUR) {
+  }
+  else if (mode == ALARM_ONCE_PER_HOUR)
+  {
     dateAlarm |= (1 << BP_ALARM_AE);     // AE_WD = 1
     hoursAlarm |= (1 << BP_ALARM_AE);    // AE_H = 1
     minutesAlarm &= ~(1 << BP_ALARM_AE); // AE_M = 0
-  } else {
+  }
+  else
+  {
     // All disabled
     dateAlarm |= (1 << BP_ALARM_AE);    // AE_WD = 1
     hoursAlarm |= (1 << BP_ALARM_AE);   // AE_H = 1
@@ -363,22 +450,26 @@ bool RV3028C7::setDateAlarm(AlarmMode_t mode, uint8_t dayOfMonth, uint8_t hour,
 }
 
 bool RV3028C7::setWeekdayAlarm(AlarmMode_t mode, DayOfWeek_t dayOfWeek,
-                               uint8_t hour, uint8_t minute) {
+                               uint8_t hour, uint8_t minute)
+{
   // Clears AIE and AF bits to 0
   uint8_t status = readByteFromRegister(REG_STATUS);
-  if (!writeByteToRegister(REG_STATUS, (status & ~(1 << BP_REG_STATUS_AF)))) {
+  if (!writeByteToRegister(REG_STATUS, (status & ~(1 << BP_REG_STATUS_AF))))
+  {
     return false;
   }
   uint8_t control2 = readByteFromRegister(REG_CONTROL_2);
   if (!writeByteToRegister(REG_CONTROL_2,
-                           (control2 & ~(1 << BP_REG_CONTROL_2_AIE)))) {
+                           (control2 & ~(1 << BP_REG_CONTROL_2_AIE))))
+  {
     return false;
   }
 
   // Sets WADA bit to 0
   uint8_t control1 = readByteFromRegister(REG_CONTROL_1);
   if (!writeByteToRegister(REG_CONTROL_1,
-                           (control1 & ~(1 << BP_REG_CONTROL_1_WADA)))) {
+                           (control1 & ~(1 << BP_REG_CONTROL_1_WADA))))
+  {
     return false;
   }
 
@@ -388,23 +479,32 @@ bool RV3028C7::setWeekdayAlarm(AlarmMode_t mode, DayOfWeek_t dayOfWeek,
   uint8_t weekdayAlarm = convertToBCD(dayOfWeek);
 
   // Sets AE_x bits according to alarm mode
-  if (mode == ALARM_ONCE_PER_DAY_OF_MONTH_OR_WEEK) {
+  if (mode == ALARM_ONCE_PER_DAY_OF_MONTH_OR_WEEK)
+  {
     weekdayAlarm &= ~(1 << BP_ALARM_AE); // AE_WD = 0
     hoursAlarm &= ~(1 << BP_ALARM_AE);   // AE_H = 0
     minutesAlarm &= ~(1 << BP_ALARM_AE); // AE_M = 0
-  } else if (mode == ALARM_ONCE_PER_HOUR_PER_DAY_OF_MONTH_OR_WEEK) {
+  }
+  else if (mode == ALARM_ONCE_PER_HOUR_PER_DAY_OF_MONTH_OR_WEEK)
+  {
     weekdayAlarm &= ~(1 << BP_ALARM_AE); // AE_WD = 0
     hoursAlarm |= (1 << BP_ALARM_AE);    // AE_H = 1
     minutesAlarm &= ~(1 << BP_ALARM_AE); // AE_M = 0
-  } else if (mode == ALARM_ONCE_PER_DAY) {
+  }
+  else if (mode == ALARM_ONCE_PER_DAY)
+  {
     weekdayAlarm |= (1 << BP_ALARM_AE);  // AE_WD = 1
     hoursAlarm &= ~(1 << BP_ALARM_AE);   // AE_H = 0
     minutesAlarm &= ~(1 << BP_ALARM_AE); // AE_M = 0
-  } else if (mode == ALARM_ONCE_PER_HOUR) {
+  }
+  else if (mode == ALARM_ONCE_PER_HOUR)
+  {
     weekdayAlarm |= (1 << BP_ALARM_AE);  // AE_WD = 1
     hoursAlarm |= (1 << BP_ALARM_AE);    // AE_H = 1
     minutesAlarm &= ~(1 << BP_ALARM_AE); // AE_M = 0
-  } else {
+  }
+  else
+  {
     // All disabled
     weekdayAlarm |= (1 << BP_ALARM_AE); // AE_WD = 1
     hoursAlarm |= (1 << BP_ALARM_AE);   // AE_H = 1
@@ -415,11 +515,13 @@ bool RV3028C7::setWeekdayAlarm(AlarmMode_t mode, DayOfWeek_t dayOfWeek,
   return writeBytesToRegisters(REG_ALARM_MINUTES, alarmRegisters, 3);
 }
 
-bool RV3028C7::setDailyAlarm(uint8_t hour, uint8_t minute) {
+bool RV3028C7::setDailyAlarm(uint8_t hour, uint8_t minute)
+{
   return setDateAlarm(ALARM_ONCE_PER_DAY, 1, hour, minute);
 }
 
-bool RV3028C7::setHourlyAlarm(uint8_t minute) {
+bool RV3028C7::setHourlyAlarm(uint8_t minute)
+{
   return setDateAlarm(ALARM_ONCE_PER_HOUR, 1, 0, minute);
 }
 
@@ -427,88 +529,106 @@ bool RV3028C7::disableAlarm() { return setDateAlarm(ALARM_DISABLED, 1, 0, 0); }
 
 bool RV3028C7::setPeriodicCountdownTimer(uint16_t timerValue,
                                          TimerClockFrequency_t frequency,
-                                         bool repeat) {
-  if (timerValue < 1) {
+                                         bool repeat)
+{
+  if (timerValue < 1)
+  {
     return false;
   }
 
   // Clears TE, TIE, and TF bits to 0
   uint8_t status = readByteFromRegister(REG_STATUS);
-  if (!writeByteToRegister(REG_STATUS, (status & ~(1 << BP_REG_STATUS_TF)))) {
+  if (!writeByteToRegister(REG_STATUS, (status & ~(1 << BP_REG_STATUS_TF))))
+  {
     return false;
   }
   uint8_t control1 = readByteFromRegister(REG_CONTROL_1);
   if (!writeByteToRegister(REG_CONTROL_1,
-                           (control1 & ~(1 << BP_REG_CONTROL_1_TE)))) {
+                           (control1 & ~(1 << BP_REG_CONTROL_1_TE))))
+  {
     return false;
   }
   uint8_t control2 = readByteFromRegister(REG_CONTROL_2);
   if (!writeByteToRegister(REG_CONTROL_2,
-                           (control2 & ~(1 << BP_REG_CONTROL_2_TIE)))) {
+                           (control2 & ~(1 << BP_REG_CONTROL_2_TIE))))
+  {
     return false;
   }
 
   // Sets TRPT bit to 1 for a repeating timer
-  if (repeat) {
+  if (repeat)
+  {
     control1 |= (1 << BP_REG_CONTROL_1_TRPT);
-  } else {
+  }
+  else
+  {
     control1 &= ~(1 << BP_REG_CONTROL_1_TRPT);
   }
 
   // Sets timer value and clock frequency
-  if (!writeByteToRegister(REG_TIMER_VALUE_0, (uint8_t)timerValue)) {
+  if (!writeByteToRegister(REG_TIMER_VALUE_0, (uint8_t)timerValue))
+  {
     return false;
   }
-  if (!writeByteToRegister(REG_TIMER_VALUE_1, (uint8_t)(timerValue >> 8))) {
+  if (!writeByteToRegister(REG_TIMER_VALUE_1, (uint8_t)(timerValue >> 8)))
+  {
     return false;
   }
   control1 |= (frequency << BP_REG_CONTROL_1_TD_LSB);
   return writeByteToRegister(REG_CONTROL_1, control1);
 }
 
-bool RV3028C7::startPeriodicCountdownTimer() {
+bool RV3028C7::startPeriodicCountdownTimer()
+{
   uint8_t control1 = readByteFromRegister(REG_CONTROL_1);
   control1 |= (1 << BP_REG_CONTROL_1_TE);
   return writeByteToRegister(REG_CONTROL_1, control1);
 }
 
-bool RV3028C7::stopPeriodicCountdownTimer() {
+bool RV3028C7::stopPeriodicCountdownTimer()
+{
   uint8_t control1 = readByteFromRegister(REG_CONTROL_1);
   control1 &= ~(1 << BP_REG_CONTROL_1_TE);
   return writeByteToRegister(REG_CONTROL_1, control1);
 }
 
-bool RV3028C7::enableInterrupt(InterruptType_t type) {
+bool RV3028C7::enableInterrupt(InterruptType_t type)
+{
   uint8_t control2 = readByteFromRegister(REG_CONTROL_2);
   control2 |= (1 << type);
   return writeByteToRegister(REG_CONTROL_2, control2);
 }
 
-bool RV3028C7::disableInterrupt(InterruptType_t type) {
+bool RV3028C7::disableInterrupt(InterruptType_t type)
+{
   uint8_t control2 = readByteFromRegister(REG_CONTROL_2);
   control2 &= ~(1 << type);
   return writeByteToRegister(REG_CONTROL_2, control2);
 }
 
-bool RV3028C7::disableAllInterrupts() {
+bool RV3028C7::disableAllInterrupts()
+{
   uint8_t control2 = readByteFromRegister(REG_CONTROL_2);
   control2 &= ~BM_REG_CONTROL_2_INTERRUPT_ENABLE_ALL;
   return writeByteToRegister(REG_CONTROL_2, control2);
 }
 
-bool RV3028C7::isInterruptDetected(InterruptType_t type) {
+bool RV3028C7::isInterruptDetected(InterruptType_t type)
+{
   uint8_t status = readByteFromRegister(REG_STATUS);
   status &= (1 << (type - 1)); // Interrupt flag bit positions are offset by 1
   return (status > 0);
 }
 
-bool RV3028C7::clearInterrupt(InterruptType_t type) {
+bool RV3028C7::clearInterrupt(InterruptType_t type)
+{
   uint8_t status = readByteFromRegister(REG_STATUS);
   status &= ~(1 << (type - 1));
   return writeByteToRegister(REG_STATUS, status);
 }
 
-bool RV3028C7::clearAllInterrupts() {
+bool RV3028C7::clearAllInterrupts()
+{
   uint8_t status = readByteFromRegister(REG_STATUS);
   status &= ~BM_REG_STATUS_INTERRUPT_FLAGS;
   return writeByteToRegister(REG_STATUS, status);
@@ -516,7 +636,8 @@ bool RV3028C7::clearAllInterrupts() {
 
 uint32_t RV3028C7::convertToUnixTimestamp(uint16_t year, uint8_t month,
                                           uint8_t dayOfMonth, uint8_t hour,
-                                          uint8_t minute, uint8_t second) {
+                                          uint8_t minute, uint8_t second)
+{
   struct tm tm;
   tm.tm_sec = second;
   tm.tm_min = minute;
@@ -528,60 +649,73 @@ uint32_t RV3028C7::convertToUnixTimestamp(uint16_t year, uint8_t month,
   return mktime(&tm);
 }
 
-uint8_t RV3028C7::convertToDecimal(uint8_t bcd) {
+uint8_t RV3028C7::convertToDecimal(uint8_t bcd)
+{
   return (bcd / 16 * 10) + (bcd % 16);
 }
 
-uint8_t RV3028C7::convertToBCD(uint8_t decimal) {
+uint8_t RV3028C7::convertToBCD(uint8_t decimal)
+{
   return (decimal / 10 * 16) + (decimal % 10);
 }
 
-bool RV3028C7::waitForEEPROM(uint8_t timeoutMS) {
+bool RV3028C7::waitForEEPROM(uint8_t timeoutMS)
+{
   uint32_t deadline = millis() + timeoutMS;
   bool timeout = false;
-  while ((readByteFromRegister(REG_STATUS) & (1 << BP_REG_STATUS_EEBUSY)) > 0) {
-    if (millis() > deadline) {
+  while ((readByteFromRegister(REG_STATUS) & (1 << BP_REG_STATUS_EEBUSY)) > 0)
+  {
+    if (millis() > deadline)
+    {
       return false;
     }
   }
   return true;
 }
 
-bool RV3028C7::enableEEPROMAutoRefresh() {
+bool RV3028C7::enableEEPROMAutoRefresh()
+{
   // Enables auto refresh by clearing EERD control bit to 0
   uint8_t control1 = readByteFromRegister(REG_CONTROL_1);
   control1 &= ~(1 << BP_REG_CONTROL_1_EERD);
   return writeByteToRegister(REG_CONTROL_1, control1);
 }
 
-bool RV3028C7::disableEEPROMAutoRefresh() {
+bool RV3028C7::disableEEPROMAutoRefresh()
+{
   // Disables auto refresh by setting EERD control bit to 1
   uint8_t control1 = readByteFromRegister(REG_CONTROL_1);
   control1 |= (1 << BP_REG_CONTROL_1_EERD);
   return writeByteToRegister(REG_CONTROL_1, control1);
 }
 
-bool RV3028C7::refreshConfigurationEEPROMToRAM() {
+bool RV3028C7::refreshConfigurationEEPROMToRAM()
+{
   // Disables auto refresh
-  if (!disableEEPROMAutoRefresh()) {
+  if (!disableEEPROMAutoRefresh())
+  {
     return false;
   }
 
   // Ensures EEPROM is not busy
-  if (!waitForEEPROM()) {
+  if (!waitForEEPROM())
+  {
     return false;
   }
 
   // Sends first EECMD
-  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_FIRST)) {
+  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_FIRST))
+  {
     return false;
   }
 
   // Sends refresh EECMD and waits ~3.5 ms
-  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_REFRESH)) {
+  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_REFRESH))
+  {
     return false;
   }
-  if (waitForEEPROM()) {
+  if (waitForEEPROM())
+  {
     // Re-enables auto refresh
     enableEEPROMAutoRefresh();
   }
@@ -589,27 +723,33 @@ bool RV3028C7::refreshConfigurationEEPROMToRAM() {
   return true;
 }
 
-bool RV3028C7::updateConfigurationEEPROMFromRAM() {
+bool RV3028C7::updateConfigurationEEPROMFromRAM()
+{
   // Disables auto refresh
-  if (!disableEEPROMAutoRefresh()) {
+  if (!disableEEPROMAutoRefresh())
+  {
     return false;
   }
 
   // Ensures EEPROM is not busy
-  if (!waitForEEPROM()) {
+  if (!waitForEEPROM())
+  {
     return false;
   }
 
   // Sends first EECMD
-  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_FIRST)) {
+  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_FIRST))
+  {
     return false;
   }
 
   // Sends update EECMD and waits ~63 ms
-  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_UPDATE)) {
+  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_UPDATE))
+  {
     return false;
   }
-  if (waitForEEPROM()) {
+  if (waitForEEPROM())
+  {
     // Re-enables auto refresh
     enableEEPROMAutoRefresh();
   }
@@ -617,32 +757,39 @@ bool RV3028C7::updateConfigurationEEPROMFromRAM() {
   return true;
 }
 
-uint8_t RV3028C7::readByteFromEEPROM(uint8_t address) {
+uint8_t RV3028C7::readByteFromEEPROM(uint8_t address)
+{
   // Disables auto refresh
-  if (!disableEEPROMAutoRefresh()) {
+  if (!disableEEPROMAutoRefresh())
+  {
     return false;
   }
 
   // Ensures EEPROM is not busy
-  if (!waitForEEPROM()) {
+  if (!waitForEEPROM())
+  {
     return false;
   }
 
   // Writes address to EEADDR register
-  if (!writeByteToRegister(REG_EE_ADDRESS, address)) {
+  if (!writeByteToRegister(REG_EE_ADDRESS, address))
+  {
     return false;
   }
 
   // Sends first EECMD
-  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_FIRST)) {
+  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_FIRST))
+  {
     return false;
   }
 
   // Sends update EECMD and waits ~1.4 ms
-  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_READ_ONE_EEPROM_BYTE)) {
+  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_READ_ONE_EEPROM_BYTE))
+  {
     return false;
   }
-  if (waitForEEPROM()) {
+  if (waitForEEPROM())
+  {
     // Re-enables auto refresh
     enableEEPROMAutoRefresh();
   }
@@ -650,37 +797,45 @@ uint8_t RV3028C7::readByteFromEEPROM(uint8_t address) {
   return readByteFromRegister(REG_EE_DATA);
 }
 
-bool RV3028C7::writeByteToEEPROM(uint8_t address, uint8_t value) {
+bool RV3028C7::writeByteToEEPROM(uint8_t address, uint8_t value)
+{
   // Disables auto refresh
-  if (!disableEEPROMAutoRefresh()) {
+  if (!disableEEPROMAutoRefresh())
+  {
     return false;
   }
 
   // Ensures EEPROM is not busy
-  if (!waitForEEPROM()) {
+  if (!waitForEEPROM())
+  {
     return false;
   }
 
   // Writes address to EEADDR register
-  if (!writeByteToRegister(REG_EE_ADDRESS, address)) {
+  if (!writeByteToRegister(REG_EE_ADDRESS, address))
+  {
     return false;
   }
 
   // Writes data to EEDATA register
-  if (!writeByteToRegister(REG_EE_DATA, value)) {
+  if (!writeByteToRegister(REG_EE_DATA, value))
+  {
     return false;
   }
 
   // Sends first EECMD
-  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_FIRST)) {
+  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_FIRST))
+  {
     return false;
   }
 
   // Sends update EECMD and waits ~16 ms
-  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_WRITE_ONE_EEPROM_BYTE)) {
+  if (!writeByteToRegister(REG_EE_COMMAND, EECMD_WRITE_ONE_EEPROM_BYTE))
+  {
     return false;
   }
-  if (waitForEEPROM()) {
+  if (waitForEEPROM())
+  {
     // Re-enables auto refresh
     enableEEPROMAutoRefresh();
   }
@@ -689,29 +844,34 @@ bool RV3028C7::writeByteToEEPROM(uint8_t address, uint8_t value) {
 }
 
 bool RV3028C7::readBytesFromRegisters(uint8_t startAddress,
-                                      uint8_t *destination, uint8_t length) {
+                                      uint8_t *destination, uint8_t length)
+{
   _i2cPort->beginTransmission(RV3028C7_ADDRESS);
   _i2cPort->write(startAddress);
   _i2cPort->endTransmission(false);
 
   _i2cPort->requestFrom((uint8_t)RV3028C7_ADDRESS, length);
-  for (uint8_t i = 0; i < length; i++) {
+  for (uint8_t i = 0; i < length; i++)
+  {
     destination[i] = _i2cPort->read();
   }
   return (_i2cPort->endTransmission() == 0);
 }
 
 bool RV3028C7::writeBytesToRegisters(uint8_t startAddress, uint8_t *values,
-                                     uint8_t length) {
+                                     uint8_t length)
+{
   _i2cPort->beginTransmission(RV3028C7_ADDRESS);
   _i2cPort->write(startAddress);
-  for (uint8_t i = 0; i < length; i++) {
+  for (uint8_t i = 0; i < length; i++)
+  {
     _i2cPort->write(values[i]);
   }
   return (_i2cPort->endTransmission() == 0);
 }
 
-uint8_t RV3028C7::readByteFromRegister(uint8_t address) {
+uint8_t RV3028C7::readByteFromRegister(uint8_t address)
+{
   uint8_t value = 0;
 
   _i2cPort->beginTransmission(RV3028C7_ADDRESS);
@@ -725,7 +885,8 @@ uint8_t RV3028C7::readByteFromRegister(uint8_t address) {
   return value;
 }
 
-bool RV3028C7::writeByteToRegister(uint8_t address, uint8_t value) {
+bool RV3028C7::writeByteToRegister(uint8_t address, uint8_t value)
+{
   _i2cPort->beginTransmission(RV3028C7_ADDRESS);
   _i2cPort->write(address);
   _i2cPort->write(value);

--- a/src/RV3028C7.h
+++ b/src/RV3028C7.h
@@ -158,7 +158,8 @@
 
 #define DATETIME_COMPONENTS 7
 
-enum DateTimeComponent {
+enum DateTimeComponent
+{
   DATETIME_SECOND = 0,
   DATETIME_MINUTE = 1,
   DATETIME_HOUR = 2,
@@ -169,7 +170,8 @@ enum DateTimeComponent {
 };
 typedef uint8_t DateTimeComponent_t;
 
-enum DayOfWeek {
+enum DayOfWeek
+{
   SUN = 0,
   MON = 1,
   TUE = 2,
@@ -180,7 +182,8 @@ enum DayOfWeek {
 };
 typedef uint8_t DayOfWeek_t;
 
-enum ClockOutputFrequency {
+enum ClockOutputFrequency
+{
   CLKOUT_32768HZ = 0,
   CLKOUT_8192HZ = 1,
   CLKOUT_1024HZ = 2,
@@ -192,7 +195,8 @@ enum ClockOutputFrequency {
 };
 typedef uint8_t ClockOutputFrequency_t;
 
-enum AlarmMode {
+enum AlarmMode
+{
   ALARM_DISABLED = 0,
   ALARM_ONCE_PER_DAY_OF_MONTH_OR_WEEK = 1,
   ALARM_ONCE_PER_HOUR_PER_DAY_OF_MONTH_OR_WEEK = 2,
@@ -201,7 +205,8 @@ enum AlarmMode {
 };
 typedef uint8_t AlarmMode_t;
 
-enum InterruptType {
+enum InterruptType
+{
   INTERRPUT_PERIODIC_TIME_UPDATE = BP_REG_CONTROL_2_UIE,
   INTERRUPT_PERIODIC_COUNTDOWN_TIMER = BP_REG_CONTROL_2_TIE,
   INTERRUPT_ALARM = BP_REG_CONTROL_2_AIE,
@@ -209,7 +214,8 @@ enum InterruptType {
 };
 typedef uint8_t InterruptType_t;
 
-enum TimerClockFrequency {
+enum TimerClockFrequency
+{
   TIMER_4096HZ = 0,
   TIMER_64HZ = 1,
   TIMER_1HZ = 2,
@@ -217,7 +223,8 @@ enum TimerClockFrequency {
 };
 typedef uint8_t TimerClockFrequency_t;
 
-class RV3028C7 {
+class RV3028C7
+{
 public:
   RV3028C7();
   bool begin(TwoWire &wirePort = Wire);

--- a/src/RV3028C7.h
+++ b/src/RV3028C7.h
@@ -233,6 +233,7 @@ public:
   bool setUnixTimestamp(uint32_t secondsSinceEpoch, bool syncCalendar = true);
 
   char *getCurrentDateTime();
+  uint8_t getCurrentDateTimeComponent(DateTimeComponent_t component);
   void setDateTimeFromISO8601(String iso8601);
   void setDateTimeFromISO8601(const char *iso8601);
   void setDateTimeFromHTTPHeader(String str);


### PR DESCRIPTION
## Example:

RV3028C7 rtc;
uint8_t currentMinute = rtc.getCurrentDateTimeComponent(DATETIME_MINUTE);

/*
component:
DATETIME_SECOND
DATETIME_MINUTE
DATETIME_HOUR
DATETIME_DAY_OF_WEEK
DATETIME_DAY_OF_MONTH
DATETIME_MONTH
DATETIME_YEAR
*/